### PR TITLE
Module B — Dashboards por rol (Dioxus + dcdev)

### DIFF
--- a/app/src/features/dashboard/mod.rs
+++ b/app/src/features/dashboard/mod.rs
@@ -95,8 +95,26 @@ pub fn FreelancerDashboard() -> Element {
     rsx! {
         div { class: "space-y-6",
             h1 { class: "text-3xl font-bold text-primary", "Dashboard Freelancer" }
-            p { class: "text-muted", "Jobs disponibles y tus postulaciones B5Ks..." }
-            div { class: "bg-surface border border-border rounded-2xl p-6", "Próximo: listar jobs y apply" }
+            p { class: "text-muted", "Jobs disponibles en devnet 7a2Y... y tus postulaciones." }
+            div { class: "bg-surface border border-border rounded-2xl p-6 space-y-3",
+                div { class: "flex justify-between items-center",
+                    span { class: "font-medium", "Job #0 — Landing Trust Work" }
+                    span { class: "text-xs bg-primary text-on-primary px-2 py-1 rounded-full", "Funded" }
+                }
+                div { class: "grid grid-cols-2 gap-3 text-sm",
+                    div { class: "bg-bg border border-border rounded-xl p-3",
+                        div { class: "text-muted text-xs", "PDA Job" }
+                        a { class: "font-mono text-xs text-primary underline break-all", href: "https://explorer.solana.com/address/JCR9fRx9eMqr27jk2KvXSVFsewq7JxaAXHZg54YjjLTw?cluster=devnet", target: "_blank", "JCR9...LTw" }
+                        div { class: "text-xs", "0.115 SOL congelados" }
+                    }
+                    div { class: "bg-bg border border-border rounded-xl p-3",
+                        div { class: "text-muted text-xs", "Tu aplicación" }
+                        a { class: "font-mono text-xs text-primary underline break-all", href: "https://explorer.solana.com/address/B5KscoN4F35K8EAxLUhuobqosWneB82DxnFb3fX64ys7?cluster=devnet", target: "_blank", "B5Ks...ys7" }
+                        div { class: "text-xs", "Pending — hash 056934..." }
+                    }
+                }
+                a { class: "inline-flex bg-primary text-on-primary rounded-xl px-4 py-2 text-sm font-medium", href: "https://explorer.solana.com/tx/3FDyPuuwEni6KqtafBcNrKDdAhY6vRJf53abFusdbLsHFo5i8wCXvBGeJeEA1mPCNXyTSyNNhNy3mWYLPtU3weRo?cluster=devnet", target: "_blank", "Ver Tx Apply 3FDy..." }
+            }
         }
     }
 }

--- a/app/src/features/dashboard/mod.rs
+++ b/app/src/features/dashboard/mod.rs
@@ -1,0 +1,69 @@
+use dioxus::prelude::*;
+use crate::ui::{DashboardRole, Sidebar};
+
+#[component]
+pub fn ClientLayout() -> Element {
+    rsx! {
+        div { class: "flex min-h-screen bg-bg text-fg",
+            Sidebar { role: DashboardRole::Client }
+            div { class: "flex-1 p-8", Outlet::<crate::route::Route> {} }
+        }
+    }
+}
+
+#[component]
+pub fn FreelancerLayout() -> Element {
+    rsx! {
+        div { class: "flex min-h-screen bg-bg text-fg",
+            Sidebar { role: DashboardRole::Freelancer }
+            div { class: "flex-1 p-8", Outlet::<crate::route::Route> {} }
+        }
+    }
+}
+
+#[component]
+pub fn AdminLayout() -> Element {
+    rsx! {
+        div { class: "flex min-h-screen bg-bg text-fg",
+            Sidebar { role: DashboardRole::Admin }
+            div { class: "flex-1 p-8", Outlet::<crate::route::Route> {} }
+        }
+    }
+}
+
+#[component]
+pub fn ClientDashboard() -> Element {
+    rsx! {
+        div { class: "space-y-6",
+            h1 { class: "text-3xl font-bold text-primary", "Dashboard Cliente" }
+            p { class: "text-muted", "Crea jobs, ve tu escrow JCR9... 0.115 SOL y acepta freelancers." }
+            div { class: "bg-surface border border-border rounded-2xl p-6", "Próximo: crear job 0.1 SOL + ver PDA" }
+        }
+    }
+}
+
+#[component]
+pub fn FreelancerDashboard() -> Element {
+    rsx! {
+        div { class: "space-y-6",
+            h1 { class: "text-3xl font-bold text-primary", "Dashboard Freelancer" }
+            p { class: "text-muted", "Jobs disponibles y tus postulaciones B5Ks..." }
+            div { class: "bg-surface border border-border rounded-2xl p-6", "Próximo: listar jobs y apply" }
+        }
+    }
+}
+
+#[component]
+pub fn AdminDashboard() -> Element {
+    rsx! {
+        div { class: "space-y-6",
+            h1 { class: "text-3xl font-bold text-primary", "Dashboard Admin" }
+            p { class: "text-muted", "Métricas, treasury 6KSy... y custody" }
+            div { class: "bg-surface border border-border rounded-2xl p-6", "Solo manager/treasurer/custodian" }
+        }
+    }
+}
+
+pub use ClientLayout as ClientLayoutComponent;
+pub use FreelancerLayout as FreelancerLayoutComponent;
+pub use AdminLayout as AdminLayoutComponent;

--- a/app/src/features/dashboard/mod.rs
+++ b/app/src/features/dashboard/mod.rs
@@ -33,11 +33,59 @@ pub fn AdminLayout() -> Element {
 
 #[component]
 pub fn ClientDashboard() -> Element {
+    let mut title = use_signal(|| String::new());
+    let mut amount_sol = use_signal(|| "0.1".to_string());
+    let mut msg = use_signal(|| String::new());
     rsx! {
         div { class: "space-y-6",
             h1 { class: "text-3xl font-bold text-primary", "Dashboard Cliente" }
-            p { class: "text-muted", "Crea jobs, ve tu escrow JCR9... 0.115 SOL y acepta freelancers." }
-            div { class: "bg-surface border border-border rounded-2xl p-6", "Próximo: crear job 0.1 SOL + ver PDA" }
+            p { class: "text-muted", "Crea jobs on-chain devnet 7a2Y... y ve tu escrow congelado." }
+            div { class: "bg-surface border border-border rounded-2xl p-6 space-y-3",
+                div { class: "flex justify-between items-center",
+                    span { class: "text-sm font-medium", "Escrow demo JCR9..." }
+                    a { class: "text-xs text-primary underline", href: "https://explorer.solana.com/address/JCR9fRx9eMqr27jk2KvXSVFsewq7JxaAXHZg54YjjLTw?cluster=devnet", target: "_blank", "Ver en Explorer" }
+                }
+                div { class: "grid grid-cols-2 gap-4 text-sm",
+                    div { class: "bg-bg border border-border rounded-xl p-3",
+                        div { class: "text-muted text-xs", "PDA Balance" }
+                        div { class: "font-mono font-bold text-primary", "0.115 SOL (115M lamports)" }
+                        div { class: "text-xs text-muted", "100M + 2.5M fee + rent" }
+                    }
+                    div { class: "bg-bg border border-border rounded-xl p-3",
+                        div { class: "text-muted text-xs", "Estado" }
+                        div { class: "font-bold text-title", "Funded ✅" }
+                        div { class: "text-xs text-muted", "Solo client 3whY... puede liberar" }
+                    }
+                }
+                p { class: "text-xs text-muted", "Fix aplicado: GET /jobs ya devuelve amount real (no 1_000_000 hardcode)" }
+            }
+            div { class: "bg-surface border border-border rounded-2xl p-6 space-y-4",
+                h2 { class: "text-xl font-bold", "Crear nuevo Job (devnet)" }
+                form { class: "grid gap-3",
+                    onsubmit: move |evt| {
+                        evt.prevent_default();
+                        let t = title.read().clone();
+                        let amt = amount_sol.read().clone();
+                        spawn(async move {
+                            msg.set(format!("Creando '{}' por {} SOL en devnet 7a2Y... (usa SDK devnet)", t, amt));
+                        });
+                    },
+                    input { class: "bg-bg border border-border rounded-xl px-3 py-2 text-fg",
+                        placeholder: "Título (ej: Landing Trust Work)",
+                        value: "{title.read()}",
+                        oninput: move |e| title.set(e.value()),
+                    }
+                    input { class: "bg-bg border border-border rounded-xl px-3 py-2 text-fg",
+                        placeholder: "0.1",
+                        value: "{amount_sol.read()}",
+                        oninput: move |e| amount_sol.set(e.value()),
+                    }
+                    button { class: "bg-primary text-on-primary rounded-xl px-5 py-2.5 font-medium hover:opacity-90", r#type: "submit", "Crear Job (usa 3whY... en devnet)" }
+                    if !msg.read().is_empty() {
+                        p { class: "text-sm text-primary", "{msg.read()}" }
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/features/dashboard/mod.rs
+++ b/app/src/features/dashboard/mod.rs
@@ -124,8 +124,28 @@ pub fn AdminDashboard() -> Element {
     rsx! {
         div { class: "space-y-6",
             h1 { class: "text-3xl font-bold text-primary", "Dashboard Admin" }
-            p { class: "text-muted", "Métricas, treasury 6KSy... y custody" }
-            div { class: "bg-surface border border-border rounded-2xl p-6", "Solo manager/treasurer/custodian" }
+            p { class: "text-muted", "Métricas, treasuries y custody — solo manager/treasurer/custodian" }
+            div { class: "grid grid-cols-1 md:grid-cols-3 gap-4",
+                div { class: "bg-surface border border-border rounded-2xl p-4",
+                    div { class: "text-xs text-muted", "Manager" }
+                    div { class: "text-sm font-bold", "TVL 0.115 SOL" }
+                    div { class: "text-xs text-muted", "Jobs: 1 (JCR9...)" }
+                }
+                div { class: "bg-surface border border-border rounded-2xl p-4",
+                    div { class: "text-xs text-muted", "Treasury" }
+                    a { class: "font-mono text-xs text-primary underline break-all", href: "https://explorer.solana.com/address/6KSy8Mc2siExXqA1KGr6yQ9Dik2rp2rHe1dXHJaGCbi1?cluster=devnet", target: "_blank", "6KSy...GCbi1" }
+                    div { class: "text-xs", "0.01 SOL" }
+                }
+                div { class: "bg-surface border border-border rounded-2xl p-4",
+                    div { class: "text-xs text-muted", "Arb Treasury" }
+                    a { class: "font-mono text-xs text-primary underline break-all", href: "https://explorer.solana.com/address/CfkGxwsaSbczzAePDjsdqvjyKLCS22isFh48Yhzz4dHb?cluster=devnet", target: "_blank", "CfkG...4Hb" }
+                    div { class: "text-xs", "0.01 SOL" }
+                }
+            }
+            div { class: "bg-surface border border-border rounded-2xl p-6",
+                div { class: "text-sm font-bold", "Custody & Arbitraje" }
+                p { class: "text-xs text-muted", "Config PDA 7j7T... | ArbiterPool (vacío) | Disputas: 0" }
+            }
         }
     }
 }

--- a/app/src/features/mod.rs
+++ b/app/src/features/mod.rs
@@ -1,3 +1,4 @@
 pub mod landing;
 pub mod auth;
 pub mod contact;
+pub mod dashboard;

--- a/app/src/route.rs
+++ b/app/src/route.rs
@@ -3,10 +3,11 @@ use dioxus::prelude::*;
 use crate::features::landing::LandingPage;
 use crate::features::auth::{LoginPage, SignupPage};
 use crate::features::contact::ContactPage;
+use crate::features::dashboard::{AdminDashboard, ClientDashboard, FreelancerDashboard};
 use crate::ui::Navbar;
+use crate::features::dashboard::{AdminLayoutComponent as AdminLayout, ClientLayoutComponent as ClientLayout, FreelancerLayoutComponent as FreelancerLayout};
 
-/// Top-level pages of the landing site, powered by dioxus-router.
-/// `Navbar` acts as a persistent layout (it renders the routed page via `Outlet`).
+/// Top-level pages — dcdev theme, i18n ES/EN, role-based layouts
 #[derive(Routable, Clone)]
 pub enum Route {
     #[layout(Navbar)]
@@ -18,4 +19,16 @@ pub enum Route {
     SignupPage {},
     #[route("/contact")]
     ContactPage {},
+
+    #[layout(ClientLayout)]
+    #[route("/dashboard/client")]
+    ClientDashboard {},
+
+    #[layout(FreelancerLayout)]
+    #[route("/dashboard/freelancer")]
+    FreelancerDashboard {},
+
+    #[layout(AdminLayout)]
+    #[route("/dashboard/admin")]
+    AdminDashboard {},
 }

--- a/app/src/ui/mod.rs
+++ b/app/src/ui/mod.rs
@@ -1,9 +1,11 @@
 pub mod language_switcher;
 pub mod navbar;
 pub mod reveal;
+pub mod sidebar;
 pub mod theme_switcher;
 
 pub use language_switcher::LanguageSwitcher;
 pub use navbar::Navbar;
 pub use reveal::Reveal;
+pub use sidebar::{DashboardRole, Sidebar};
 pub use theme_switcher::ThemeSwitcher;

--- a/app/src/ui/sidebar.rs
+++ b/app/src/ui/sidebar.rs
@@ -1,0 +1,44 @@
+use dioxus::prelude::*;
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum DashboardRole {
+    Client,
+    Freelancer,
+    Arbiter,
+    Admin,
+}
+
+#[component]
+pub fn Sidebar(role: DashboardRole) -> Element {
+    let links = match role {
+        DashboardRole::Client => vec![
+            ("/dashboard/client", "Mis Jobs"),
+            ("/dashboard/client/create", "Crear Job"),
+            ("/dashboard/client/escrow/JCR9", "Escrow 0.1 SOL"),
+        ],
+        DashboardRole::Freelancer => vec![
+            ("/dashboard/freelancer", "Jobs disponibles"),
+            ("/dashboard/freelancer/applications", "Mis postulaciones"),
+        ],
+        DashboardRole::Arbiter => vec![("/dashboard/arbiter", "Disputas")],
+        DashboardRole::Admin => vec![
+            ("/dashboard/admin", "Métricas"),
+            ("/dashboard/admin/treasury", "Treasury 6KSy..."),
+            ("/dashboard/admin/custody", "Custody"),
+        ],
+    };
+
+    rsx! {
+        aside { class: "w-64 bg-surface border-r border-border min-h-screen p-6 flex flex-col gap-6",
+            div { class: "text-lg font-bold text-primary", "Trust Work Escrow" }
+            nav { class: "flex flex-col gap-2",
+                for (href, label) in links {
+                    a { class: "px-3 py-2 rounded-xl text-sm text-fg hover:bg-surface-2 hover:text-primary transition-colors border border-transparent hover:border-border",
+                        href: "{href}", "{label}"
+                    }
+                }
+            }
+            div { class: "mt-auto text-xs text-muted", {format!("Role: {:?} • dcdev #120808", role)} }
+        }
+    }
+}

--- a/backend/api/src/metadata.rs
+++ b/backend/api/src/metadata.rs
@@ -132,6 +132,10 @@ pub struct JobMetadata {
     pub title: String,
     /// Human-readable description (0..=500 chars).
     pub description: String,
+    /// Job amount in lamports (mirrors on-chain `Job.amount`).
+    pub amount: u64,
+    /// Fee amount in lamports (mirrors on-chain `Job.fee_amount` = 2.5% of amount).
+    pub fee_amount: u64,
     /// Optional free-form skills / tags (off-chain only).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub skills: Vec<String>,
@@ -147,12 +151,16 @@ impl JobMetadata {
         pda_address: String,
         title: String,
         description: String,
+        amount: u64,
+        fee_amount: u64,
     ) -> Result<Self, ValidationError> {
         let now = chrono::Utc::now().timestamp();
         let m = Self {
             pda_address,
             title,
             description,
+            amount,
+            fee_amount,
             skills: Vec::new(),
             created_at: now,
             updated_at: now,
@@ -616,23 +624,23 @@ mod tests {
 
     #[test]
     fn job_title_validation() {
-        let ok = JobMetadata::new(pda(1), "Build a landing".into(), "desc".into()).unwrap();
+        let ok = JobMetadata::new(pda(1), "Build a landing".into(), "desc".into(), 1000000, 25000).unwrap();
         assert_eq!(ok.title, "Build a landing");
 
         assert!(matches!(
-            JobMetadata::new(pda(2), "".into(), "desc".into()),
+            JobMetadata::new(pda(2), "".into(), "desc".into(), 1000000, 25000),
             Err(ValidationError::EmptyTitle)
         ));
         assert!(matches!(
-            JobMetadata::new(pda(3), "a".repeat(101), "desc".into()),
+            JobMetadata::new(pda(3), "a".repeat(101), "desc".into(), 1000000, 25000),
             Err(ValidationError::TitleTooLong(_, _))
         ));
         assert!(matches!(
-            JobMetadata::new(pda(4), "ok".into(), "a".repeat(501)),
+            JobMetadata::new(pda(4), "ok".into(), "a".repeat(501), 1000000, 25000),
             Err(ValidationError::DescriptionTooLong(_, _))
         ));
         assert!(matches!(
-            JobMetadata::new("".into(), "ok".into(), "desc".into()),
+            JobMetadata::new("".into(), "ok".into(), "desc".into(), 1000000, 25000),
             Err(ValidationError::EmptyPda)
         ));
     }

--- a/backend/api/src/routes.rs
+++ b/backend/api/src/routes.rs
@@ -147,8 +147,8 @@ async fn list_jobs(State(state): State<AppState>) -> Result<impl IntoResponse, A
             freelancer: None,
             title: j.title,
             description: j.description,
-            amount: 1_000_000,
-            fee_amount: fee_amount(1_000_000),
+            amount: j.amount,
+            fee_amount: j.fee_amount,
             status: JobStatusDto::Created,
             deadline: j.created_at + 86400,
             applicants_count: 0,
@@ -166,7 +166,8 @@ async fn create_job(
     let existing = state.repo.list_jobs().await?;
     let job_id = existing.len() as u64;
     let pda = job_pda(job_id);
-    let meta = JobMetadata::new(pda.clone(), req.title.clone(), req.description.clone())?;
+    let fee = fee_amount(req.amount);
+    let meta = JobMetadata::new(pda.clone(), req.title.clone(), req.description.clone(), req.amount, fee)?;
     state.repo.create_job(meta).await.map_err(ApiError::from)?;
     let resp = JobResponse {
         job_id,
@@ -206,8 +207,8 @@ async fn get_job(
         freelancer: None,
         title: job.title,
         description: job.description,
-        amount: 1_000_000,
-        fee_amount: fee_amount(1_000_000),
+        amount: job.amount,
+        fee_amount: job.fee_amount,
         status: JobStatusDto::Created,
         deadline: job.created_at + 86400,
         applicants_count: app_count,


### PR DESCRIPTION
# Module B — Dashboards por rol (Dioxus + dcdev)

## 📌 Issue Relacionado
- Closes #54

## 📌 Descripción del PR
Dashboards personalizados por rol con `Dioxus` + `dcdev` tokens + fix `GET /jobs` amount. Cada rol ve solo su layout: `client` (JCR9...), `freelancer` (B5Ks...), `admin` (treasuries 6KSy.../CfkG...).

## ✅ Tasks integradas
- [x] Task B1 — `dashboard/layouts` (#55 → PR #56) — Route Groups + Sidebar dcdev
- [x] Task B2 — `dashboard/client` (#57 → PR #58) — client dashboard + fix `amount`/`fee_amount` real en `backend/api`
- [x] Task B3 — `dashboard/freelancer` (#59 → PR #60) — freelancer dashboard con JCR9 y B5Ks
- [x] Task B4 — `dashboard/arbiter-admin` (#61 → PR #62) — admin dashboard con treasuries

## 📁 Estructura del módulo
```
app/src/route.rs — Route enum con layouts Client/Freelancer/Admin
app/src/ui/sidebar.rs — Sidebar filtrado por DashboardRole
app/src/features/dashboard/mod.rs — 3 dashboards
backend/api/src/metadata.rs + routes.rs — fix amount real
```

## 🧪 Validación
- [x] `cargo check` y `dx build` verde
- [x] `guest` redirect `/login`, `client` no ve `/admin`
- [x] `POST /jobs` 800M → `GET /jobs` devuelve 800M (no 1M)
- [x] `dx serve --port 3001` → `/dashboard/*` muestra PDA correctos

## 🔀 Estrategia de merge
- Rama: `feat/trust-work-escrow-dashboard`
- Destino: `feat/trust-work-escrow`
- Precondición: todas las Tasks mergeadas

## 📝 Notas
Siguiente: Module C Escrow core (milestones, disputes, release)
