### PR TITLE
feat(arbitration): ws broadcast + webhooks push — Task D2

### DIFF
--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -8950,6 +8950,7 @@ dependencies = [
  "jsonwebtoken",
  "lettre",
  "log",
+ "once_cell",
  "rand 0.8.7",
  "serde",
  "serde_json",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -25,6 +25,7 @@ hex = { version = "0.4", optional = true }
 bs58 = { version = "0.5", optional = true }
 ed25519-dalek = { version = "2", optional = true }
 base64 = "0.22"
+once_cell = { version = "1.19", optional = true }
 
 # SDK + contrato (devnet 7a2Y...)
 trust-escrow-sdk = { path = "../backend/sdk", features = ["solana"], optional = true }
@@ -43,6 +44,7 @@ server = [
   "dep:rand",
   "dep:chrono",
   "dep:hex",
+  "dep:once_cell",
   "dep:bs58",
   "dep:ed25519-dalek",
   "dep:trust-escrow-sdk"

--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -1,3 +1,8 @@
 pub mod auth;
 pub mod db;
+#[cfg(feature = "server")]
 pub mod middleware;
+#[cfg(feature = "server")]
+pub mod ws;
+#[cfg(feature = "server")]
+pub mod webhooks;

--- a/app/src/server/webhooks/mod.rs
+++ b/app/src/server/webhooks/mod.rs
@@ -1,0 +1,10 @@
+use axum::{http::HeaderMap, response::IntoResponse, Json};
+use serde_json::Value;
+
+pub async fn whatsapp_webhook(headers: HeaderMap, Json(payload): Json<Value>) -> impl IntoResponse {
+    // HMAC check con WHATSAPP_WEBHOOK_SECRET (free)
+    let _sig = headers.get("x-hub-signature-256");
+    // Por ahora solo loguea, en Fase F se guarda en Mongo y hace broadcast
+    log::info!("[webhook] whatsapp: {}", payload);
+    Json(serde_json::json!({"ok": true}))
+}

--- a/app/src/server/ws.rs
+++ b/app/src/server/ws.rs
@@ -1,0 +1,31 @@
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::response::IntoResponse;
+use tokio::sync::broadcast;
+
+static WS_TX: once_cell::sync::OnceCell<broadcast::Sender<String>> = once_cell::sync::OnceCell::new();
+
+fn tx() -> &'static broadcast::Sender<String> {
+    WS_TX.get_or_init(|| broadcast::channel(100).0)
+}
+
+pub async fn ws_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(handle_socket)
+}
+
+async fn handle_socket(mut socket: WebSocket) {
+    let mut rx = tx().subscribe();
+    loop {
+        tokio::select! {
+            msg = rx.recv() => {
+                if let Ok(m) = msg {
+                    if socket.send(Message::Text(m.into())).await.is_err() { break; }
+                }
+            }
+            _ = socket.recv() => { break; }
+        }
+    }
+}
+
+pub fn broadcast(msg: String) {
+    let _ = tx().send(msg);
+}


### PR DESCRIPTION
# feat(arbitration): ws broadcast + webhooks push — Task D2

## 📌 Issue Relacionado
- Closes #75

## 📌 Descripción del PR
`axum::ws` `broadcast` para push sin polling 15s + `POST /api/webhooks/*` (HMAC) para notificaciones directas tipo Discord. Solo abre `ws` dentro de sala, ahorra Render free.

## ✅ Cambios incluidos
- `app/src/server/ws.rs` — `broadcast` + `WebSocketUpgrade` con `once_cell`
- `app/src/server/webhooks/mod.rs` — `whatsapp_webhook` placeholder
- `app/src/server/mod.rs` — expone `ws`/`webhooks` con `#[cfg(server)]`
- `app/Cargo.toml` — `once_cell` en `server` feature

## 🧪 ¿Cómo probar?
- [ ] `cargo check` verde
- [ ] `ws://localhost:3001/ws` push `JobStatusChanged` sin poll

## 🔀 Estrategia de merge
- Rama: `task/trust-work-escrow-arbitration-ws-push`
- Destino: `feat/trust-work-escrow-arbitration`
