### PR TITLE
Module F — Deploy y tracción (Render + WhatsApp reserva)

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,17 @@
+# Dioxus fullstack — Render Web Service (free)
+FROM rust:1.82-bookworm AS builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY assets ./assets
+COPY tailwind.css ./
+RUN cargo build --release --features server
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /app/target/release/trust-work-escrow-app /usr/local/bin/app
+COPY assets ./assets
+ENV PORT=10000
+EXPOSE 10000
+CMD ["app"]

--- a/docs/DEPLOY_RENDER.md
+++ b/docs/DEPLOY_RENDER.md
@@ -1,0 +1,24 @@
+# Deploy Render — Trust Work Escrow (devnet)
+
+Todo en Render free, sin depender de tu PC.
+
+## Servicios
+- `app` (Dioxus fullstack Rust) — Web Service, `PORT=0.0.0.0:10000`, `Dockerfile` Rust
+- `twe-postgres` — Render PostgreSQL free
+- `twe-mongo` — Mongo Atlas M0 free (o Render Private Service `mongo:7`)
+
+## Env
+```
+SOLANA_RPC_URL=https://api.devnet.solana.com
+DATABASE_URL=postgres://...
+MONGO_URL=mongodb+srv://...
+SMTP_HOST=smtp.gmail.com
+```
+
+## Webhooks/WS
+- `POST /api/webhooks/whatsapp` — placeholder, feature flag `whatsapp` apagado hasta Fase F2
+- `ws://app.onrender.com/ws` — solo dentro de sala arbitraje, no 24/7
+
+## Verificación
+- `https://app.onrender.com/health` → `{"rpc":"ok"}`
+- Explorer: JCR9... 0.115 SOL


### PR DESCRIPTION
# Module F — Deploy y tracción (Render + WhatsApp reserva)

## 📌 Issue Relacionado
- Closes #82

## 📌 Descripción del PR
Deploy 100% online en Render (app Dioxus + Postgres + Mongo) + placeholder WhatsApp (`/api/webhooks/whatsapp` apagado) + docs.

## ✅ Cambios incluidos
- `app/Dockerfile` — Rust 1.82 builder + debian slim, `PORT=10000`
- `docs/DEPLOY_RENDER.md` — servicios, env, webhooks/ws

## 🧪 Validación
- [x] `docker build` OK
- [x] `dx build` OK

## 🔀 Estrategia de merge
- Rama: `feat/trust-work-escrow-deploy`
- Destino: `feat/trust-work-escrow`
